### PR TITLE
Add verification of `issuer` in JWTs

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ function reload_validators (options) {
     Object.keys(certs).forEach(function (kid) {
       validators[kid] = expressJwt({
         audience: options.client_id,
-        secret: certs[kid]
+        secret: certs[kid],
+        issuer: ["accounts.google.com", "https://accounts.google.com"]
       });
     });
   });

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function (options) {
     var auth_header = req.get('Authorization');
 
     if (!auth_header || !auth_header.match(/^Bearer\s/)) {
-      return res.send(401, 'missing authorization header');
+      return res.status(401).send('missing authorization header');
     }
 
     var token = auth_header.replace(/^Bearer\s/, '');

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "BSD",
   "dependencies": {
-    "express-jwt": "~2.1.0",
+    "express-jwt": "^3.0.0",
     "request": "~2.34.0"
   }
 }


### PR DESCRIPTION
Hi, hope this helps in improving the security of the module.

As specified by the guides, https://developers.google.com/identity/sign-in/web/backend-auth#verify-the-integrity-of-the-id-token the issuer should be verified too.

NOTE: Sorry about the added space at the end. Github did it, blame them :-) Anyway, I think it is an okay thing.
